### PR TITLE
RHOAIENG-19618: Bump Go to 1.23 (#52)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ###############################################################################
 # Stage 1: Create the developer image for the BUILDPLATFORM only
 ###############################################################################
-ARG GOLANG_VERSION=1.22
+ARG GOLANG_VERSION=1.23
 ARG BUILD_BASE=develop
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS develop
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/rest-proxy
 
-go 1.22.9
+go 1.23.6
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Fix CVE `CVE-2025-22866`.

CP of: https://github.com/kserve/rest-proxy/commit/979f9b9a51a793c01b155ab3831b2af2d76d85d1