### PR TITLE
Odh v2.33 release

### DIFF
--- a/.tekton/odh-mm-rest-proxy-push.yaml
+++ b/.tekton/odh-mm-rest-proxy-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/rest-proxy:odh-v2.33
+    value: quay.io/opendatahub/rest-proxy:odh-v2.34
   - name: dockerfile
     value: Dockerfile
   - name: path-context


### PR DESCRIPTION
Update Tekton output-image tags to version odh-v2.34
[RHOAIENG-30987]