### PR TITLE
Add Konflux ODH tag bump automation to our existing release workflow.

### DIFF
--- a/.github/workflows/create-tag-release.yml
+++ b/.github/workflows/create-tag-release.yml
@@ -4,8 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Tag name for the new release'
+        description: 'New release tag (e.g., odh-v2.35)'
         required: true
+        type: string
+      next_odh_tag:
+        description: 'Next development tag (e.g., odh-v2.36)'
+        required: true
+        type: string
+    # Note: This workflow assumes the release tag and image tags are in sync.
+    #       'tag_name' is used to create the release and as the value to find in files.
+    #       'next_odh_tag' provides the new value to set.
 
 permissions:
   contents: write
@@ -80,3 +88,42 @@ jobs:
           files: bin/*
           generate_release_notes: true
           name: ${{ github.event.inputs.tag_name }}
+
+  bump-odh-tag:
+    name: Bump ODH Tag for Next Release
+    runs-on: ubuntu-latest
+    needs: changelog
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Update odh-mm-rest-proxy-push.yaml with next ODH tag
+        run: |
+          CURRENT_TAG="${{ github.event.inputs.tag_name }}"
+          NEXT_TAG="${{ github.event.inputs.next_odh_tag }}"
+          
+          echo "Updating ODH tag from $CURRENT_TAG to $NEXT_TAG..."
+          
+          # Using sed to replace the current ODH tag with the next one,
+          # anchored to the image name to prevent over-matching.
+          sed -i "s|rest-proxy:${CURRENT_TAG}|rest-proxy:${NEXT_TAG}|g" .tekton/odh-mm-rest-proxy-push.yaml
+          
+          echo "Update complete."
+          
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add .tekton/odh-mm-rest-proxy-push.yaml
+          
+          # Check for changes before committing
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes to commit. Exiting."
+          else
+            git commit -m "chore(konflux): Bump ODH release tag to ${{ github.event.inputs.next_odh_tag }}"
+            git push
+          fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a new job to the `create-release.yaml` workflow to automate the process of updating the ODH release tag in the `rest-proxy` repository's `Tekton` build file. This automation prepares the repository for the next development cycle by using the `next_odh_tag` input to update the relevant files. The change is committed directly to the branch after the release is finalized.

## How Has This Been Tested?
This change was tested in a dedicated test environment on a separate branch, `RHOAIENG-31952-test`, to prevent any impact on the main codebase.

- **Testing Environment:** A dedicated GitHub branch was created on the `rest-proxy` repository.
- **Test Ran:** The workflow was manually triggered using the `workflow_dispatch` event with the following inputs:
  - `tag_name:` `odh-v2.35`
  - `next_odh_tag:` `odh-v2.36`
- **Verification:** After the workflow completed, the `.tekton/odh-mm-rest-proxy-push.yaml` file was manually checked. The `value` field was successfully updated from `quay.io/opendatahub/rest-proxy:odh-v2.35` to `quay.io/opendatahub/rest-proxy:odh-v2.36`. The test-generated commits were reverted and squashed for a clean PR.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
