### PR TITLE
Upgrade to Go 1.25.5 for CVE-2025-61729

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.60.3
+    rev: v2.8.0
     hooks:
       - id: golangci-lint
         log_file: .pre-commit.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ###############################################################################
 # Stage 1: Create the developer image for the BUILDPLATFORM only
 ###############################################################################
-ARG GOLANG_VERSION=1.23
+ARG GOLANG_VERSION=1.25
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS develop
 
 ARG PROTOC_VERSION=21.12

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/rest-proxy
 
-go 1.23.6
+go 1.25.5
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
## Summary

Upgrades the project to Go 1.25.5+ to address **[CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2)** (excessive resource consumption in `crypto/x509` when printing error strings for host certificate validation).

## Changes

- **go.mod**: Require `go 1.25.5` (first release containing the fix).
- **Dockerfile**: `GOLANG_VERSION=1.25` (UBI go-toolset:1.25).
- **.pre-commit-config.yaml**: golangci-lint `v2.8.0` (replaces v1.60.3) for Go 1.25 compatibility.

## References

- [CVE-2025-61729](https://nvd.nist.gov/vuln/detail/CVE-2025-61729) / [GO-2025-4155](https://pkg.go.dev/vuln/GO-2025-4155)
- Fix included in Go 1.24.11 and 1.25.5+